### PR TITLE
feat: list events

### DIFF
--- a/backend/current/schema/types.py
+++ b/backend/current/schema/types.py
@@ -1,48 +1,114 @@
 import graphene
 from graphene_django import DjangoObjectType
-from main.models import MockElement
 from django.contrib.gis.db.models import PointField
 from graphene_django.converter import convert_django_field
+
+from main.models import Evento, Usuario, Calendario
+
 
 class CoordinatesType(graphene.ObjectType):
     longitude = graphene.Float()
     latitude = graphene.Float()
 
+
 @convert_django_field.register(PointField)
 def convert_point_field_to_coordinates(field, registry=None):
     return graphene.Field(CoordinatesType)
 
-class MockElementType(DjangoObjectType):
-    punto_geografico = graphene.Field(CoordinatesType)
-    
+
+class UserType(DjangoObjectType):
     class Meta:
-        model = MockElement
-        fields = ['id', 'nombre', 'punto_geografico', 'created_at']
-    
-    def resolve_punto_geografico(self, info):
-        """Convierte el Point de PostGIS a coordenadas"""
-        if self.punto_geografico:
-            return CoordinatesType(
-                longitude=self.punto_geografico.x,
-                latitude=self.punto_geografico.y
-            )
-        return None
+        model = Usuario
+        fields = [
+            "id",
+            "username",
+            "first_name",
+            "last_name",
+            "pronombres",
+            "biografia",
+            "link",
+            "foto",
+        ]
+
+
+class EventType(DjangoObjectType):
+    class Meta:
+        model = Evento
+        fields = [
+            "id",
+            "titulo",
+            "descripcion",
+            "nombre_lugar",
+            "ubicacion",
+            "fecha",
+            "hora",
+            "foto",
+            "recurrencia",
+            "creador",
+        ]
+
+    def resolve_ubicacion(self, info):
+        if self.ubicacion:
+            return CoordinatesType(self.ubicacion.x, self.ubicacion.y)
+
 
 class Query(graphene.ObjectType):
-    all_mock_elements = graphene.List(MockElementType)
-    mock_element = graphene.Field(MockElementType, id=graphene.Int(required=True))
-    mock_elements_by_name = graphene.List(MockElementType, nombre=graphene.String())
-    
-    def resolve_all_mock_elements(self, info):
-        return MockElement.objects.all()
-    
-    def resolve_mock_element(self, info, id):
+    all_events = graphene.List(
+        EventType,
+        week=graphene.Int(),
+        month=graphene.Int(),
+        year=graphene.Int(),
+    )
+
+    event_by_id = graphene.Field(EventType, id=graphene.ID(required=True))
+
+    events_of_user = graphene.List(
+        EventType,
+        id=graphene.ID(required=True),
+        week=graphene.Int(),
+        month=graphene.Int(),
+        year=graphene.Int(),
+    )
+
+    def resolve_all_events(
+        self,
+        info,
+        week: int | None = None,
+        month: int | None = None,
+        year: int | None = None,
+    ):
+        q = Evento.objects.select_related("creador").all()
+
+        if week and 1 <= week <= 53:
+            q = q.filter(fecha__week=week)
+        if month and 1 <= month <= 12:
+            q = q.filter(fecha__month=month)
+        if year:
+            q = q.filter(fecha__year=year)
+
+        return q
+
+    def resolve_event_by_id(self, info, id):
         try:
-            return MockElement.objects.get(pk=id)
-        except MockElement.DoesNotExist:
+            return Evento.objects.select_related("creador").get(pk=id)
+        except Evento.DoesNotExist:
             return None
-    
-    def resolve_mock_elements_by_name(self, info, nombre=None):
-        if nombre:
-            return MockElement.objects.filter(nombre__icontains=nombre)
-        return MockElement.objects.all()
+
+    def resolve_events_of_user(
+        self,
+        info,
+        id,
+        week: int | None = None,
+        month: int | None = None,
+        year: int | None = None,
+    ):
+        q = Evento.objects.filter(creador_id=id)
+
+        if week and 1 <= week <= 53:
+            q = q.filter(fecha__week=week)
+        if month and 1 <= month <= 12:
+            q = q.filter(fecha__month=month)
+        if year:
+            q = q.filter(fecha__year=year)
+
+        return q

--- a/backend/main/tests_graphql.py
+++ b/backend/main/tests_graphql.py
@@ -1,0 +1,151 @@
+from graphene_django.utils.testing import GraphQLTestCase
+from datetime import date, time
+from rest_framework.test import APIClient
+
+from .models import Usuario, Evento, Calendario
+
+
+class MyFancyTestCase(GraphQLTestCase):
+
+    GRAPHQL_URL = "/graphql/"
+    client_class = APIClient
+
+    def setUp(self) -> None:
+        self.user1 = Usuario.objects.create_user(
+            username="user1", email="user1@example.com", password="user1"
+        )
+        self.user2 = Usuario.objects.create_user(
+            username="user2", email="user2@example.com", password="user2"
+        )
+
+        self.cal1 = Calendario.objects.create(
+            nombre="Calendario Privado",
+            estado="PRIVADO",
+            creador=self.user1,
+        )
+
+        self.cal2 = Calendario.objects.create(
+            nombre="Calendario para Amigos",
+            estado="AMIGOS",
+            creador=self.user2,
+        )
+
+        self.event1 = Evento.objects.create(
+            titulo="Cena cumpleaños",
+            descripcion="Nos vemos en el restaurante de siempre.",
+            fecha=date(2026, 3, 20),
+            hora=time(21, 00),
+            creador=self.user1,
+        )
+        self.event1.calendarios.add(self.cal1)
+        self.event1.save()
+
+        self.event2 = Evento.objects.create(
+            titulo="Reunión secreta",
+            descripcion="Solo para mis amigos.",
+            fecha=date(2026, 4, 20),
+            hora=time(10, 00),
+            creador=self.user2,
+        )
+        self.event2.calendarios.add(self.cal2)
+        self.event2.save()
+
+    def test_all_events(self) -> None:
+        response = self.query(
+            """
+            {
+                allEvents {
+                    id
+                    titulo
+                    descripcion
+                }
+            }
+            """,
+        )
+
+        self.assertResponseNoErrors(response)
+
+        data = response.json()
+
+        self.assertEqual(len(data["data"]["allEvents"]), 2)
+        self.assertEqual(data["data"]["allEvents"][0]["titulo"], "Cena cumpleaños")
+        self.assertEqual(data["data"]["allEvents"][1]["titulo"], "Reunión secreta")
+
+    def test_all_events_date(self) -> None:
+        response = self.query(
+            """
+            {
+                allEvents(month: 4, year: 2026) {
+                    id
+                    titulo
+                    descripcion
+                }
+            }
+            """,
+        )
+
+        self.assertResponseNoErrors(response)
+
+        data = response.json()
+
+        self.assertEqual(len(data["data"]["allEvents"]), 1)
+        self.assertEqual(data["data"]["allEvents"][0]["titulo"], "Reunión secreta")
+
+    def test_event_by_id(self) -> None:
+        response = self.query(
+            f"""
+            {{
+                eventById(id: {self.event1.pk}) {{
+                    id
+                    titulo
+                    descripcion
+                }}
+            }}
+            """,
+        )
+
+        self.assertResponseNoErrors(response)
+
+        data = response.json()
+
+        self.assertEqual(data["data"]["eventById"]["titulo"], "Cena cumpleaños")
+
+    def test_events_of_user(self) -> None:
+        response = self.query(
+            f"""
+            {{
+                eventsOfUser(id: {self.user2.pk}) {{
+                    id
+                    titulo
+                    descripcion
+                }}
+            }}
+            """,
+        )
+
+        self.assertResponseNoErrors(response)
+
+        data = response.json()
+
+        self.assertEqual(len(data["data"]["eventsOfUser"]), 1)
+        self.assertEqual(data["data"]["eventsOfUser"][0]["titulo"], "Reunión secreta")
+
+    def test_events_of_user_date(self) -> None:
+        response = self.query(
+            f"""
+            {{
+                eventsOfUser(id: {self.user2.pk}, year: 2026) {{
+                    id
+                    titulo
+                    descripcion
+                }}
+            }}
+            """,
+        )
+
+        self.assertResponseNoErrors(response)
+
+        data = response.json()
+
+        self.assertEqual(len(data["data"]["eventsOfUser"]), 1)
+        self.assertEqual(data["data"]["eventsOfUser"][0]["titulo"], "Reunión secreta")


### PR DESCRIPTION
He añadido consultas para:

* Obtener todos los eventos. Puede filtrarse por número de semana, mes y/o año.
* Obtener el detalle de un único evento.
* Obtener todos los eventos de un usuario. Puede filtrarse por número de semana, mes y/o año.

No entiendo muy bien cómo va lo de los calendarios privados/para amigos. Ahora mismo todos los evento son públicos.