### PR TITLE
feat: Navegación hacia el calendario que se crea

### DIFF
--- a/frontend/app/(tabs)/create.tsx
+++ b/frontend/app/(tabs)/create.tsx
@@ -29,6 +29,11 @@ interface PublishData {
   privacy: PrivacyStatus;
   origin?: CalendarOrigin;
 }
+
+type CreatedCalendarResponse = {
+  id?: number | string;
+};
+
 export default function CreateScreen() {
   const router = useRouter();
   const { user } = useAuth();
@@ -130,11 +135,16 @@ export default function CreateScreen() {
         formData.append("cover", blob, filename);
       }
 
-      await createCalendar(formData);
+      const createdCalendar = await createCalendar(formData) as CreatedCalendarResponse;
+      const createdCalendarId = createdCalendar?.id;
 
       Alert.alert("Success", "Calendar created successfully.");
 
-      router.replace("/(tabs)/calendars");
+      if (createdCalendarId !== undefined && createdCalendarId !== null) {
+        router.replace(`/(tabs)/calendars?selectedCalendarId=${encodeURIComponent(String(createdCalendarId))}`);
+      } else {
+        router.replace("/(tabs)/calendars");
+      }
 
     } catch (error: any) {
       console.log("FULL ERROR:", error);


### PR DESCRIPTION
Antes, al crear un calendario redirigía a una pantalla general donde se veían los eventos de todos los calendarios, ahora se ha cambiado para que aparezca el calendario que se ha creado para que se pueda añadir eventos ahí nada más crearlo.