### PR TITLE
feat: Se mejora la interfaz de los calendarios del feed para que se e…

### DIFF
--- a/frontend/components/event-calendar/calendar-card.tsx
+++ b/frontend/components/event-calendar/calendar-card.tsx
@@ -20,10 +20,45 @@ export default function CalendarCard({
   onComment,
   isSubscribed = false,
 }: CalendarCardProps) {
-  const privacyIcon: Record<string, any> = {
-    PRIVATE: "lock-closed",
-    FRIENDS: "people",
-    PUBLIC: "globe",
+  const privacyMeta: Record<
+    string,
+    {
+      icon: any;
+      label: string;
+      bgColor: string;
+      borderColor: string;
+      textColor: string;
+    }
+  > = {
+    PRIVATE: {
+      icon: "lock-closed",
+      label: "Private",
+      bgColor: "#EFEFF2",
+      borderColor: "#D9D9DE",
+      textColor: "#4A4A56",
+    },
+    FRIENDS: {
+      icon: "people",
+      label: "Friends",
+      bgColor: "#E7F4FF",
+      borderColor: "#B9DEFF",
+      textColor: "#155A8A",
+    },
+    PUBLIC: {
+      icon: "globe",
+      label: "Public",
+      bgColor: "#EAF8EE",
+      borderColor: "#BFE7C9",
+      textColor: "#1F6A36",
+    },
+  };
+
+  const selectedPrivacy = privacyMeta[calendar.privacy] ?? {
+    icon: "help",
+    label: "Unknown",
+    bgColor: "#F3F3F3",
+    borderColor: "#DCDCDC",
+    textColor: "#666",
   };
 
   const originIcon: Record<string, any> = {
@@ -59,17 +94,33 @@ export default function CalendarCard({
             <Text style={eventCalendarCalendarCardStyles.creator}>by {calendar.creator}</Text>
           </View>
           <View style={eventCalendarCalendarCardStyles.badges}>
-            <Ionicons
-              name={privacyIcon[calendar.privacy] || "help"}
-              size={16}
-              color="#666"
-              style={eventCalendarCalendarCardStyles.badge}
-            />
-            <Ionicons
-              name={originIcon[calendar.origin] || "help"}
-              size={16}
-              color="#666"
-            />
+            <View
+              style={[
+                eventCalendarCalendarCardStyles.privacyBadge,
+                {
+                  backgroundColor: selectedPrivacy.bgColor,
+                  borderColor: selectedPrivacy.borderColor,
+                },
+              ]}
+            >
+              <Ionicons name={selectedPrivacy.icon} size={14} color={selectedPrivacy.textColor} />
+              <Text
+                style={[
+                  eventCalendarCalendarCardStyles.privacyBadgeText,
+                  { color: selectedPrivacy.textColor },
+                ]}
+              >
+                {selectedPrivacy.label}
+              </Text>
+            </View>
+
+            <View style={eventCalendarCalendarCardStyles.originBadge}>
+              <Ionicons
+                name={originIcon[calendar.origin] || "help"}
+                size={14}
+                color="#4F4F59"
+              />
+            </View>
           </View>
         </View>
 

--- a/frontend/styles/calendar-styles.ts
+++ b/frontend/styles/calendar-styles.ts
@@ -453,9 +453,33 @@ export const eventCalendarCalendarCardStyles = StyleSheet.create({
   badges: {
     flexDirection: 'row',
     gap: 6,
+    alignItems: 'center',
   },
   badge: {
     marginLeft: 8,
+  },
+  privacyBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    borderRadius: 999,
+    borderWidth: 1,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+  },
+  privacyBadgeText: {
+    fontSize: 11,
+    fontWeight: '700',
+  },
+  originBadge: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#DFDFE4',
+    backgroundColor: '#F4F4F6',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   description: {
     fontSize: 13,


### PR DESCRIPTION
Se modifica la visualización de los calendarios en el feed dando respuesta a la siguiente sugerencia: 

En la pestaña de los calendarios recomendados ya aparece la privacidad del calendario (un mundo – público, dos personas – para amigos, un candado – privado), pero he de decir que me ha costado darme cuenta porque no lo he visto de primeras. Pienso que estaría bien acompañar esos iconos con un pequeño texto, o meterlos en un recuadro de color para que se vea claramente sin ningún tipo de dudas qué tipo de privacidad tiene para ti ese calendario en concreto. 