### PR TITLE
fix: edit cocalendars fixed, and edit, delete and co-owners buttons fixed

### DIFF
--- a/backend/main/calendars/views.py
+++ b/backend/main/calendars/views.py
@@ -155,8 +155,11 @@ def delete_calendar(request, calendar_id):
 def edit_calendar(request, calendar_id):
     calendar = get_object_or_404(Calendar, id=calendar_id)
 
-    if calendar.creator != request.user:
-        return Response({'error': 'You do not have permission to edit this calendar.'}, status=status.HTTP_403_FORBIDDEN)
+    if calendar.creator != request.user and request.user not in calendar.co_owners.all():
+        return Response(
+        {'error': 'You do not have permission to edit this calendar.'},
+        status=status.HTTP_403_FORBIDDEN
+    )
 
     ESTADOS_VALIDOS = {'PRIVATE', 'FRIENDS', 'PUBLIC'}
     campos_editables = ['name', 'privacy', 'description']

--- a/frontend/components/calendar-info-modal.tsx
+++ b/frontend/components/calendar-info-modal.tsx
@@ -66,7 +66,14 @@ export function CalendarInfoModal({
   const accent = localCalendar.color;
   const privacy = PRIVACY_LABELS[localCalendar.privacy] ?? PRIVACY_LABELS.PRIVATE;
   const origin = ORIGIN_LABELS[localCalendar.origin] ?? ORIGIN_LABELS.CURRENT;
-  const isOwner = user && localCalendar.creator === user.username;
+  const isOwnerOrCoOwner =
+  user &&
+  (
+    localCalendar.creator === user.username ||
+    (localCalendar.co_owners ?? []).some(
+      (co: any) => co.username === user.username
+    )
+  );
   const hasCalendarCover =
         typeof localCalendar.cover === 'string' && localCalendar.cover.trim().length > 0;
 
@@ -161,7 +168,7 @@ export function CalendarInfoModal({
         </View>
 
         <View style={calendarInfoModalStyles.actions}>
-             {isOwner && (
+             {isOwnerOrCoOwner && (
                         <TouchableOpacity
                             style={calendarInfoModalStyles.inviteButton}
                             onPress={() => setInviteVisible(true)}
@@ -177,15 +184,15 @@ export function CalendarInfoModal({
                             </Text>
                         </TouchableOpacity>
                     )}
-          <TouchableOpacity
+          { isOwnerOrCoOwner && <TouchableOpacity
             style={calendarInfoModalStyles.editButton}
             onPress={() => onEdit?.(localCalendar)}
             activeOpacity={0.75}
           >
             <Ionicons name="pencil" size={16} color="#fff" />
             <Text style={calendarInfoModalStyles.editButtonLabel}>Edit calendar</Text>
-          </TouchableOpacity>
-                    {isOwner && (
+          </TouchableOpacity>}
+                    {isOwnerOrCoOwner && (
                         <TouchableOpacity
                             style={calendarInfoModalStyles.shareButton}
                             onPress={() => setShowCoOwners(true)}
@@ -207,7 +214,7 @@ export function CalendarInfoModal({
             </TouchableOpacity>
           )}
 
-          {onDelete && (
+          {isOwnerOrCoOwner && onDelete && (
             <TouchableOpacity
               style={[calendarInfoModalStyles.deleteButton, isDeleting && calendarInfoModalStyles.deleteButtonDisabled]}
               onPress={handleDeletePress}
@@ -238,7 +245,7 @@ export function CalendarInfoModal({
         onCalendarUpdated={handleCalendarUpdated}
       />
 
-            {isOwner && (
+            {isOwnerOrCoOwner && (
                 <InviteUserModal
                     visible={inviteVisible}
                     onClose={() => setInviteVisible(false)}

--- a/frontend/types/calendar.ts
+++ b/frontend/types/calendar.ts
@@ -17,6 +17,7 @@ export interface Calendar {
     color: string;          // UI-only accent color
     likes_count: number;
     liked_by_me: boolean;
+    co_owners?: { username: string; name: string }[]; // For shared calendars
 }
 
 export interface CalendarEvent {


### PR DESCRIPTION
He arreglado que saltaba un error al editar un calendario del que eras co-owner, tambien he arreglado de paso que se mostraba el boton de edit y delete a personas que no podian usarlos, al ser por ejemplo subcriptores de un evento. Tambien añado que a los co-ownewrs de le muestren los mismo botones que a los owners, basicamente tienen los mismos derechos.