### PR TITLE
fix: external links url

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,5 +1,2 @@
 EXPO_PUBLIC_API_URL=http://localhost:8000/api/v1
 EXPO_PUBLIC_API_BASE=http://localhost:8000
-# Para probar previews de compartir (WhatsApp/Telegram), ejecuta ./tunnel.sh
-# El script actualiza esta variable automáticamente y la restaura al parar.
-EXPO_PUBLIC_SHARE_BASE_URL=https://8699b19fd41869d7-217-29-101-80.serveousercontent.com

--- a/frontend/components/share-calendar-modal.tsx
+++ b/frontend/components/share-calendar-modal.tsx
@@ -11,8 +11,8 @@ import {
 import { Ionicons } from '@expo/vector-icons';
 import { Calendar } from '@/types/calendar';
 import { BottomSheetModal } from '@/components/ui/bottom-sheet-modal';
-import { API_CONFIG } from '@/constants/api';
 import { DefaultCalendarCover } from '@/components/default-calendar-cover';
+import { API_CONFIG } from '@/constants/api';
 
 interface ShareCalendarModalProps {
     calendar: Calendar | null;
@@ -24,9 +24,7 @@ export function ShareCalendarModal({ calendar, onClose }: ShareCalendarModalProp
 
     if (!calendar) return null;
 
-    const shareBaseUrl = process.env.EXPO_PUBLIC_SHARE_BASE_URL ?? API_CONFIG.rootBaseURL;
-    const shareUrl = `${shareBaseUrl}/share/calendar/${calendar.id}/`;
-    console.log('Creator:', calendar.creator);
+    const shareUrl = `${API_CONFIG.rootBaseURL}/share/calendar/${calendar.id}/`;
 
     const handleNativeShare = async () => {
         try {


### PR DESCRIPTION
¿Qué se ha cambiado?                                                                                                                                                                                                                                   
- Eliminada la variable EXPO_PUBLIC_SHARE_BASE_URL del .env del frontend.                                                                                                                                           
- El link de compartir ahora usa API_CONFIG.rootBaseURL (el backend) en lugar de una URL de túnel manual.   
                                                                                                                                                                                                                                                         
Cosas a tener en cuenta al desplegar en preproducción/producción (.env del despliegue):                                                                                                                                                                                                                                                                                                                                                                                                                                        - Backend .env — asegurarse de que FRONTEND_URL apunta a la URL real del frontend (la usa el botón "Open in Current Calendar" de la página de preview): FRONTEND_URL=https://<dominio-frontend> 
                                                                                                                                                                                                                                                                                                           
- Frontend .env — EXPO_PUBLIC_API_BASE debe apuntar al backend de ese entorno (ya determina la URL del link compartido): EXPO_PUBLIC_API_BASE=https://<dominio-backend>
                                                                                                                                                                                                                                                                                                                                        Cómo funciona el link compartido:                                                                                                                                                                                                                   - La URL que se comparte va al backend (/share/calendar/<id>/)                                                                                                                                                                                       - El backend sirve HTML con OG tags → WhatsApp/Telegram muestran la foto del calendario.                                                                                                                                                              - El usuario pulsa → ve la tarjeta con foto + botón "Open in Current Calendar" → redirige al frontend. 
                                                                                                                                              
En local no funciona el preview de WhatsApp, localhost:8000 no es accesible desde internet. Funciona correctamente a partir de preproducción. 