### PR TITLE
fix: now events appear in shared calendars

### DIFF
--- a/frontend/app/(tabs)/calendar-view.tsx
+++ b/frontend/app/(tabs)/calendar-view.tsx
@@ -41,10 +41,18 @@ export default function CalendarViewScreen() {
   const [selectedDay, setSelectedDay] = useState<string | null>(null);
   const [activeEvent, setActiveEvent] = useState<CalendarEvent | null>(null);
   const [openedEventFromParams, setOpenedEventFromParams] = useState(false);
-  
+
+  // When a specific calendarId is in the URL (e.g. via share link), fetch events
+  // for that calendar directly so public calendars always show their events.
+  useEffect(() => {
+    if (calendarId) {
+      refetchEvents(calendarId);
+    }
+  }, [calendarId, refetchEvents]);
+
   // Load events when screen gains focus
   useFocusEffect(
-    React.useCallback(() => { refetchEvents(); }, [refetchEvents])
+    React.useCallback(() => { refetchEvents(calendarId); }, [calendarId, refetchEvents])
   );
 
   const events = useMemo(() => {


### PR DESCRIPTION
Una vez se comparte el link externo se puede acceder al calendario pero no se ven sus eventos. 

El problema es que useEventsList() llama a /events/list (todos los eventos del usuario) y luego filtra por calendar.id. Cuando accedes por el link, si el calendario pertenece a otro usuario y no estás suscrito, ese calendario no aparece en tu 
/events/list → filtro vacío → sin eventos

Como solución, cuando hay calendarId en la URL, pedir los eventos específicos de ese calendario con ?calendarIds=<id>, que el backend sí devuelve para calendarios públicos sin necesitar una suscripción.