### PR TITLE
Feat/labels back

### DIFF
--- a/backend/main/labels/test_labels.py
+++ b/backend/main/labels/test_labels.py
@@ -706,6 +706,34 @@ class CategoryViewSetTests(APITestCase):
         # Debería permitir a co-owner
         self.assertIn(response.status_code, [200, 201, 204])
 
+    def test_get_categories_for_calendar(self):
+        """GET categorías asignadas a un calendario"""
+        self.calendar.categories.add(self.category1)
+        self.client.force_authenticate(user=self.owner_user)
+
+        response = self.client.get(
+            f'/api/v1/categories/for-calendar/{self.calendar.id}/',
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, HTTP_200_OK)
+        category_ids = {item['id'] for item in response.data}
+        self.assertIn(self.category1.id, category_ids)
+
+    def test_get_categories_for_calendar_forbidden_if_no_access(self):
+        """No debe permitir ver categorías de calendario privado sin acceso"""
+        self.calendar.privacy = 'PRIVATE'
+        self.calendar.save(update_fields=['privacy'])
+        self.calendar.categories.add(self.category1)
+
+        self.client.force_authenticate(user=self.other_user)
+        response = self.client.get(
+            f'/api/v1/categories/for-calendar/{self.calendar.id}/',
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, HTTP_403_FORBIDDEN)
+
 
 class EventTagViewSetTests(APITestCase):
     """Tests exhaustivos para EventTagViewSet"""
@@ -998,6 +1026,48 @@ class EventTagViewSetTests(APITestCase):
         self.assertEqual(self.event.tags.count(), 2)
         self.assertIn(self.tag1, self.event.tags.all())
         self.assertIn(self.tag2, self.event.tags.all())
+
+    def test_get_event_tags_for_calendar(self):
+        """GET tags válidos para un calendario según categorías asignadas"""
+        self.client.force_authenticate(user=self.owner_user)
+
+        response = self.client.get(
+            f'/api/v1/event-tags/for-calendar/{self.calendar.id}/',
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, HTTP_200_OK)
+        tag_ids = {item['id'] for item in response.data}
+        self.assertIn(self.tag1.id, tag_ids)
+        self.assertIn(self.tag2.id, tag_ids)
+
+    def test_get_event_tags_for_event(self):
+        """GET tags asignados a un evento concreto"""
+        self.event.tags.add(self.tag1)
+        self.client.force_authenticate(user=self.owner_user)
+
+        response = self.client.get(
+            f'/api/v1/event-tags/for-event/{self.event.id}/',
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, HTTP_200_OK)
+        tag_ids = {item['id'] for item in response.data}
+        self.assertIn(self.tag1.id, tag_ids)
+
+    def test_get_event_tags_for_event_forbidden_if_no_access(self):
+        """No debe permitir ver tags de evento privado sin acceso"""
+        self.calendar.privacy = 'PRIVATE'
+        self.calendar.save(update_fields=['privacy'])
+        self.event.tags.add(self.tag1)
+
+        self.client.force_authenticate(user=self.other_user)
+        response = self.client.get(
+            f'/api/v1/event-tags/for-event/{self.event.id}/',
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, HTTP_403_FORBIDDEN)
 
 
 class LabelViewsetHelpersTests(TestCase):

--- a/backend/main/labels/viewsets.py
+++ b/backend/main/labels/viewsets.py
@@ -91,6 +91,31 @@ class CategoryViewSet(viewsets.ModelViewSet):
             status=status.HTTP_200_OK
         )
 
+    @action(detail=False, methods=['get'], url_path=r'for-calendar/(?P<calendar_id>[^/.]+)')
+    def for_calendar(self, request, calendar_id=None):
+        """
+        Lista categorías asignadas a un calendario concreto.
+
+        GET /api/v1/categories/for-calendar/{calendar_id}/
+        """
+        calendar = get_object_or_404(Calendar, id=calendar_id)
+
+        can_access = (
+            calendar.privacy == 'PUBLIC'
+            or request.user == calendar.creator
+            or request.user in calendar.co_owners.all()
+            or request.user in calendar.viewers.all()
+            or request.user in calendar.subscribers.all()
+        )
+        if not can_access:
+            return Response(
+                {'error': 'You do not have permission to access this calendar.'},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        serializer = CategorySerializer(calendar.categories.all(), many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
     @action(detail=True, methods=['post'])
     def remove_from_calendar(self, request, pk=None):
         """
@@ -241,6 +266,62 @@ class EventTagViewSet(viewsets.ModelViewSet):
             {'message': 'This tag is not assigned to this event'},
             status=status.HTTP_200_OK
         )
+
+    @action(detail=False, methods=['get'], url_path=r'for-calendar/(?P<calendar_id>[^/.]+)')
+    def for_calendar(self, request, calendar_id=None):
+        """
+        Lista tags válidos para un calendario según sus categorías asignadas.
+
+        GET /api/v1/event-tags/for-calendar/{calendar_id}/
+        """
+        calendar = get_object_or_404(Calendar, id=calendar_id)
+
+        can_access = (
+            calendar.privacy == 'PUBLIC'
+            or request.user == calendar.creator
+            or request.user in calendar.co_owners.all()
+            or request.user in calendar.viewers.all()
+            or request.user in calendar.subscribers.all()
+        )
+        if not can_access:
+            return Response(
+                {'error': 'You do not have permission to access this calendar.'},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        tags = EventTag.objects.filter(category__in=calendar.categories.all()).distinct()
+        serializer = EventTagSerializer(tags, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @action(detail=False, methods=['get'], url_path=r'for-event/(?P<event_id>[^/.]+)')
+    def for_event(self, request, event_id=None):
+        """
+        Lista tags asignados a un evento concreto.
+
+        GET /api/v1/event-tags/for-event/{event_id}/
+        """
+        event = get_object_or_404(Event, id=event_id)
+
+        can_access = False
+        for calendar in event.calendars.all():
+            if (
+                calendar.privacy == 'PUBLIC'
+                or request.user == calendar.creator
+                or request.user in calendar.co_owners.all()
+                or request.user in calendar.viewers.all()
+                or request.user in calendar.subscribers.all()
+            ):
+                can_access = True
+                break
+
+        if not can_access:
+            return Response(
+                {'error': 'You do not have permission to access this event.'},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        serializer = EventTagSerializer(event.tags.all(), many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
 
 # Funciones utilitarias para recomendaciones y búsquedas


### PR DESCRIPTION
add extra endpoints with corresponding tests to retrieve categories and tags given a calendar and an event.