### PR TITLE
fix: el calendario desaparecia de la lista al suscribirse

### DIFF
--- a/backend/main/serializers.py
+++ b/backend/main/serializers.py
@@ -227,7 +227,7 @@ class CalendarSummarySerializer(serializers.ModelSerializer):
     creator = serializers.CharField(source="creator.username")
     liked_by_me = serializers.SerializerMethodField()
 
-    likes_count = serializers.IntegerField(source='likes.count', read_only=True)
+    likes_count = serializers.IntegerField(read_only=True)
     class Meta:
         model = Calendar
         fields = (

--- a/frontend/app/(tabs)/switch-calendar.tsx
+++ b/frontend/app/(tabs)/switch-calendar.tsx
@@ -221,7 +221,6 @@ export default function CalendarsScreen() {
 
       if (res.subscribed) {
         setSubscribedCalendarIds((prev) => [...prev, id]);
-        setCalendars((prev) => prev.filter((calendar) => calendar.id !== id));
         Alert.alert("¡Listo!", "Te has suscrito correctamente.");
       } else {
         setSubscribedCalendarIds((prev) =>


### PR DESCRIPTION
- Eliminar el filtro que borraba el calendario del estado al suscribirse en switch-calendar;
  el prop isSubscribed se actualiza reactivamente via subscribedCalendarIds
- Corregir el campo likes_count en CalendarSummarySerializer que causaba HTTP 500
  en el endpoint de recomendaciones
