### PR TITLE
fix: allow password reset page for authenticated users

### DIFF
--- a/frontend/app/(tabs)/settings.tsx
+++ b/frontend/app/(tabs)/settings.tsx
@@ -307,12 +307,6 @@ const SettingsScreen = () => {
             <Text style={styles.modalBody}>
               An email with a link to change your password has been sent to your inbox.
             </Text>
-            <View style={styles.modalWarningBox}>
-              <Ionicons name="alert-circle-outline" size={20} color="#8a2f28" />
-              <Text style={styles.modalWarningText}>
-                Before using the link, you must sign out of your account for security reasons.
-              </Text>
-            </View>
             <TouchableOpacity
               style={styles.modalButton}
               onPress={() => setIsPasswordResetModalVisible(false)}

--- a/frontend/routes-config.ts
+++ b/frontend/routes-config.ts
@@ -27,14 +27,14 @@ export const ROUTES_CONFIG: RouteConfig[] = [
     requiresGuest: true,
     redirectOnFail: "/calendars",
   },
-  {
-    path: "/new-password",
-    requiresAuth: false,
-    requiresGuest: true,
-    redirectOnFail: "/calendars",
-  },
 
   // Rutas que requieren autenticación (Auth)
+    {
+    path: "/new-password",
+    requiresAuth: false,
+    requiresGuest: false,
+    redirectOnFail: "/login",
+  },
   {
     path: "/profile",
     requiresAuth: true,


### PR DESCRIPTION
This PR fixes the password reset flow by allowing the `/new-password` route to be accessed even when the user already has an active session.

Previously, the route was configured with `requiresGuest: true`, so authenticated users opening a password reset link were redirected to `/calendars` instead of seeing the new password screen.

## Changes

- Updated the `/new-password` route guard configuration.
- Removed the guest-only restriction from the password reset page.
- Prevented password reset links from incorrectly redirecting authenticated users to `/calendars`.

## Testing

- Opened a password reset link while authenticated.
- Verified that the app stays on `/new-password?token=...`.
- Verified that unauthenticated users can still access the password reset page.