### PR TITLE
feat: fix radar privacy filter and add Redis cache to heavy endpoints

### DIFF
--- a/backend/main/consumers.py
+++ b/backend/main/consumers.py
@@ -1,6 +1,7 @@
 import json
 from channels.generic.websocket import AsyncWebsocketConsumer
 from channels.db import database_sync_to_async
+from django.core.cache import cache
 from .models import Event, ChatMessage, User
 
 class ChatConsumer(AsyncWebsocketConsumer):
@@ -54,5 +55,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
         event = Event.objects.get(id=event_id)
     
         msg = ChatMessage.objects.create(sender=user, event=event, text=text)
-        
+
+        cache.delete(f"event_chat_history_{event_id}")
+
         return ChatMessageSerializer(msg).data

--- a/backend/main/radar/tests/tests.py
+++ b/backend/main/radar/tests/tests.py
@@ -208,6 +208,30 @@ class RadarEventsTest(APITestCase):
         titles = [e["title"] for e in response.data]
         self.assertIn("Event Private", titles)
 
+    def test_calendar_owner_sees_private_calendar_event_created_by_co_owner(self):
+        owned_calendar = Calendar.objects.create(
+            name="Owned Private",
+            privacy="PRIVATE",
+            creator=self.user,
+        )
+        owned_calendar.co_owners.add(self.other)
+
+        co_owner_event = Event.objects.create(
+            title="Event by Co-Owner",
+            date=timezone.now().date(),
+            time=time(17, 0),
+            location=Point(-3.7038, 40.4168),
+            creator=self.other,
+        )
+        co_owner_event.calendars.add(owned_calendar)
+
+        self.client.login(username="user1", password="testpass")
+
+        response = self.client.get(self.url)
+
+        titles = [e["title"] for e in response.data]
+        self.assertIn("Event by Co-Owner", titles)
+
     def test_viewer_sees_private_calendar_event(self):
         self.private_calendar.viewers.add(self.user)
         self.client.login(username="user1", password="testpass")

--- a/backend/main/radar/tests/tests.py
+++ b/backend/main/radar/tests/tests.py
@@ -1,8 +1,9 @@
 from datetime import date, time
 from rest_framework.test import APITestCase
+from django.core.cache import cache
 from django.utils import timezone
 from rest_framework import status
-from main.models import Calendar, Event
+from main.models import Calendar, Event, EventAttendance
 from django.contrib.auth import get_user_model
 from django.contrib.gis.geos import Point
 
@@ -11,6 +12,7 @@ User = get_user_model()
 class RadarEventsTest(APITestCase):
 
     def setUp(self):
+        cache.clear()
         self.url = "/api/v1/radar/?lat=40.4168&lon=-3.7038&radio=10"
 
         self.user = User.objects.create_user(
@@ -158,7 +160,7 @@ class RadarEventsTest(APITestCase):
         own_event = Event.objects.create(
             title="My Own Event",
             date=date.today(),
-            time=time(16, 0),   
+            time=time(16, 0),
             location=Point(-3.7038, 40.4168),
             creator=self.user,
         )
@@ -170,3 +172,73 @@ class RadarEventsTest(APITestCase):
         response = self.client.get(self.url)
         titles = [e["title"] for e in response.data]
         self.assertIn("My Own Event", titles)
+
+    def test_invited_attendee_sees_private_event(self):
+        EventAttendance.objects.create(
+            user=self.user,
+            event=self.private_event,
+            status="ASSISTING",
+        )
+        self.client.login(username="user1", password="testpass")
+
+        response = self.client.get(self.url)
+
+        titles = [e["title"] for e in response.data]
+        self.assertIn("Event Private", titles)
+
+    def test_pending_attendee_does_not_see_private_event(self):
+        EventAttendance.objects.create(
+            user=self.user,
+            event=self.private_event,
+            status="PENDING",
+        )
+        self.client.login(username="user1", password="testpass")
+
+        response = self.client.get(self.url)
+
+        titles = [e["title"] for e in response.data]
+        self.assertNotIn("Event Private", titles)
+
+    def test_co_owner_sees_private_calendar_event(self):
+        self.private_calendar.co_owners.add(self.user)
+        self.client.login(username="user1", password="testpass")
+
+        response = self.client.get(self.url)
+
+        titles = [e["title"] for e in response.data]
+        self.assertIn("Event Private", titles)
+
+    def test_viewer_sees_private_calendar_event(self):
+        self.private_calendar.viewers.add(self.user)
+        self.client.login(username="user1", password="testpass")
+
+        response = self.client.get(self.url)
+
+        titles = [e["title"] for e in response.data]
+        self.assertIn("Event Private", titles)
+
+    def test_radar_results_are_cached(self):
+        self.client.login(username="user1", password="testpass")
+
+        first_response = self.client.get(self.url)
+        self.assertEqual(first_response.status_code, status.HTTP_200_OK)
+        first_titles = [e["title"] for e in first_response.data]
+
+        new_event = Event.objects.create(
+            title="Brand New Event",
+            date=timezone.now().date(),
+            time=time(18, 0),
+            location=Point(-3.7038, 40.4168),
+            creator=self.other,
+        )
+        new_event.calendars.add(self.public_calendar)
+
+        cached_response = self.client.get(self.url)
+        cached_titles = [e["title"] for e in cached_response.data]
+        self.assertEqual(first_titles, cached_titles)
+        self.assertNotIn("Brand New Event", cached_titles)
+
+        cache.clear()
+        fresh_response = self.client.get(self.url)
+        fresh_titles = [e["title"] for e in fresh_response.data]
+        self.assertIn("Brand New Event", fresh_titles)

--- a/backend/main/radar/views.py
+++ b/backend/main/radar/views.py
@@ -4,12 +4,16 @@ from rest_framework import status
 from django.contrib.gis.geos import Point
 from django.contrib.gis.db.models.functions import Distance
 from django.contrib.gis.measure import D
+from django.core.cache import cache
 from django.db.models import Q
 from django.utils import timezone
 from ..models import Event
 from ..serializers import EventSerializer
 from main.entitlements import get_user_features
 from current.throttles import HeavyEndpointThrottle
+
+RADAR_CACHE_TTL_SECONDS = 30
+
 
 @api_view(['GET'])
 @throttle_classes([HeavyEndpointThrottle])
@@ -38,23 +42,35 @@ def radar_events(request):
     user_location = Point(lon, lat, srid=4326)
 
     user = request.user
+    user_key = user.id if user.is_authenticated else 'anon'
+    cache_key = f"radar_events_{user_key}_{round(lat, 3)}_{round(lon, 3)}_{radio}"
+    cached_data = cache.get(cache_key)
+    if cached_data is not None:
+        return Response(cached_data, status=status.HTTP_200_OK)
+
     limit_days = 0
     if user.is_authenticated:
         user_features = get_user_features(user)
         limit_days = user_features['max_days_difference_radar']
-        filtro_privacidad = Q(calendars__privacy='PUBLIC') | Q(creator=user)
+        filtro_privacidad = (
+            Q(calendars__privacy='PUBLIC')
+            | Q(creator=user)
+            | Q(calendars__co_owners=user)
+            | Q(calendars__viewers=user)
+            | Q(attendances__user=user, attendances__status='ASSISTING')
+        )
     else:
         filtro_privacidad = Q(calendars__privacy='PUBLIC')
 
     today = timezone.now().date()
     max_date = today + timezone.timedelta(days=limit_days)
-    
+
     events = (
         Event.objects
         .filter(
             filtro_privacidad,
             location__isnull=False,
-            date__gte=timezone.now().date(),
+            date__gte=today,
             date__lte=max_date
         )
         .annotate(distance=Distance("location", user_location))
@@ -64,9 +80,11 @@ def radar_events(request):
     )
 
     serializer = EventSerializer(
-        events, 
-        many=True, 
+        events,
+        many=True,
         context={'request': request}
     )
+
+    cache.set(cache_key, serializer.data, RADAR_CACHE_TTL_SECONDS)
 
     return Response(serializer.data, status=status.HTTP_200_OK)

--- a/backend/main/radar/views.py
+++ b/backend/main/radar/views.py
@@ -5,9 +5,9 @@ from django.contrib.gis.geos import Point
 from django.contrib.gis.db.models.functions import Distance
 from django.contrib.gis.measure import D
 from django.core.cache import cache
-from django.db.models import Q
+from django.db.models import Q, Prefetch
 from django.utils import timezone
-from ..models import Event
+from ..models import Event, EventAttendance, EventLike, EventSave
 from ..serializers import EventSerializer
 from main.entitlements import get_user_features
 from current.throttles import HeavyEndpointThrottle
@@ -43,7 +43,9 @@ def radar_events(request):
 
     user = request.user
     user_key = user.id if user.is_authenticated else 'anon'
-    cache_key = f"radar_events_{user_key}_{round(lat, 3)}_{round(lon, 3)}_{radio}"
+    # 5 decimals (~1.1m) keeps the key stable when the device sits still
+    # without grouping clearly distinct positions into the same cache entry.
+    cache_key = f"radar_events_{user_key}_{round(lat, 5)}_{round(lon, 5)}_{radio}"
     cached_data = cache.get(cache_key)
     if cached_data is not None:
         return Response(cached_data, status=status.HTTP_200_OK)
@@ -55,6 +57,7 @@ def radar_events(request):
         filtro_privacidad = (
             Q(calendars__privacy='PUBLIC')
             | Q(creator=user)
+            | Q(calendars__creator=user)
             | Q(calendars__co_owners=user)
             | Q(calendars__viewers=user)
             | Q(attendances__user=user, attendances__status='ASSISTING')
@@ -64,6 +67,26 @@ def radar_events(request):
 
     today = timezone.now().date()
     max_date = today + timezone.timedelta(days=limit_days)
+
+    prefetches = [
+        'calendars',
+        Prefetch(
+            'attendances',
+            queryset=EventAttendance.objects.filter(
+                status='ASSISTING'
+            ).select_related('user'),
+        ),
+    ]
+    if user.is_authenticated:
+        prefetches.append(
+            Prefetch(
+                'attendances',
+                queryset=EventAttendance.objects.filter(user=user).only(
+                    'status', 'event_id'
+                ),
+                to_attr='my_attendance_records',
+            )
+        )
 
     events = (
         Event.objects
@@ -77,12 +100,30 @@ def radar_events(request):
         .filter(location__distance_lte=(user_location, D(km=radio)))
         .order_by("distance")
         .distinct()
+        .select_related('creator')
+        .prefetch_related(*prefetches)
     )
+
+    liked_ids, saved_ids = set(), set()
+    if user.is_authenticated:
+        event_ids = list(events.values_list('id', flat=True))
+        liked_ids = set(
+            EventLike.objects.filter(user=user, event_id__in=event_ids)
+            .values_list('event_id', flat=True)
+        )
+        saved_ids = set(
+            EventSave.objects.filter(user=user, event_id__in=event_ids)
+            .values_list('event_id', flat=True)
+        )
 
     serializer = EventSerializer(
         events,
         many=True,
-        context={'request': request}
+        context={
+            'request': request,
+            'liked_ids': liked_ids,
+            'saved_ids': saved_ids,
+        }
     )
 
     cache.set(cache_key, serializer.data, RADAR_CACHE_TTL_SECONDS)

--- a/backend/main/views.py
+++ b/backend/main/views.py
@@ -49,16 +49,20 @@ def event_chat_history(request, event_id):
     Devuelve el historial de mensajes de un evento específico.
     Solo usuarios logueados pueden pedirlo.
     """
+    cache_key = f"event_chat_history_{event_id}"
+    cached_data = cache.get(cache_key)
+    if cached_data is not None:
+        return Response(cached_data)
+
     try:
-       
         event = Event.objects.get(id=event_id)
     except Event.DoesNotExist:
         return Response({"error": "Evento no encontrado"}, status=404)
 
-    
     messages = ChatMessage.objects.filter(event=event).order_by('timestamp').select_related("sender")[:50]
-    
-   
+
     serializer = ChatMessageSerializer(messages, many=True)
-    
+
+    cache.set(cache_key, serializer.data, 30)
+
     return Response(serializer.data)


### PR DESCRIPTION
  #468 — Fix del radar (backend/main/radar/views.py):
  - El filtro de privacidad solo permitía ver eventos PUBLIC o creados por uno mismo. Por eso un usuario invitado a
  un evento privado no veía nada en el mapa.
  - Ahora incluye también: co-owners y viewers del calendario, y eventos donde el user tiene EventAttendance con
  status ASSISTING (invitación aceptada).
  - Tests añadidos en backend/main/radar/tests/tests.py: test_invited_attendee_sees_private_event,
  test_pending_attendee_does_not_see_private_event, test_co_owner_sees_private_calendar_event,
  test_viewer_sees_private_calendar_event.

  #486 — Caché Redis:
  - radar_events: cacheado por user_id+lat+lon+radio con TTL 30s (consulta geoespacial cara).
  - event_chat_history (backend/main/views.py): cacheado por event_id con TTL 30s; invalidación en consumers.py
  cuando llega un mensaje nuevo por websocket.
  - Test añadido: test_radar_results_are_cached.