### PR TITLE
fix: Use conditional render for accept optional cookies

### DIFF
--- a/frontend/app/(tabs)/privacy-settings.tsx
+++ b/frontend/app/(tabs)/privacy-settings.tsx
@@ -307,13 +307,15 @@ export default function PrivacySettingsScreen() {
               >
                 <Text style={styles.rejectButtonText}>Reject optional cookies</Text>
               </TouchableOpacity>
-              <TouchableOpacity
-                style={[styles.preferenceButton, styles.acceptButton]}
-                activeOpacity={0.85}
-                onPress={() => saveCookiePreference("accepted")}
-              >
-                <Text style={styles.acceptButtonText}>Accept optional cookies</Text>
-              </TouchableOpacity>
+              {cookiePreference !== "accepted" && (
+                <TouchableOpacity
+                  style={[styles.preferenceButton, styles.acceptButton]}
+                  activeOpacity={0.85}
+                  onPress={() => saveCookiePreference("accepted")}
+                >
+                  <Text style={styles.acceptButtonText}>Accept optional cookies</Text>
+                </TouchableOpacity>
+              )}
             </View>
           </View>
         )}


### PR DESCRIPTION
He ajustado la pantalla para que, cuando cookiePreference ya es accepted, no se renderice el botón Accept optional cookies.