### PR TITLE
fix: N+1 query in event list

### DIFF
--- a/backend/current/schema/types.py
+++ b/backend/current/schema/types.py
@@ -261,7 +261,7 @@ class Query(graphene.ObjectType):
         user = info.context.user
         if not user.is_authenticated:
             return Calendar.objects.none()
-        return Calendar.objects.filter(creator_id=user.pk)
+        return Calendar.objects.filter(creator_id=user.pk).order_by("id")
 
     def resolve_followed_calendars(self, info):
         user = info.context.user

--- a/backend/main/events/views.py
+++ b/backend/main/events/views.py
@@ -389,6 +389,7 @@ def list_events(request):
             queryset=EventAttendance.objects.filter(
                 status='ASSISTING'
             ).select_related('user'),
+            to_attr='assisting_attendances',
         ),
     ]
 

--- a/backend/main/radar/views.py
+++ b/backend/main/radar/views.py
@@ -75,6 +75,7 @@ def radar_events(request):
             queryset=EventAttendance.objects.filter(
                 status='ASSISTING'
             ).select_related('user'),
+            to_attr='assisting_attendances',
         ),
     ]
     if user.is_authenticated:
@@ -104,9 +105,11 @@ def radar_events(request):
         .prefetch_related(*prefetches)
     )
 
+    event_list = list(events)
+
     liked_ids, saved_ids = set(), set()
     if user.is_authenticated:
-        event_ids = list(events.values_list('id', flat=True))
+        event_ids = [event.id for event in event_list]
         liked_ids = set(
             EventLike.objects.filter(user=user, event_id__in=event_ids)
             .values_list('event_id', flat=True)
@@ -117,7 +120,7 @@ def radar_events(request):
         )
 
     serializer = EventSerializer(
-        events,
+        event_list,
         many=True,
         context={
             'request': request,

--- a/backend/main/serializers.py
+++ b/backend/main/serializers.py
@@ -339,11 +339,13 @@ class EventSerializer(serializers.ModelSerializer):
         return obj.location.x if obj.location else None
 
     def get_calendars(self, obj):
-        return list(obj.calendars.values_list('id', flat=True))
-    
+        return [c.id for c in obj.calendars.all()]
+
     def get_attendees(self, obj):
         """Devuelve solo asistentes (status=ASSISTING)."""
-        attendances = obj.attendances.filter(status='ASSISTING')
+        attendances = getattr(obj, 'assisting_attendances', None)
+        if attendances is None:
+            attendances = list(obj.attendances.filter(status='ASSISTING'))
         return EventAttendeeSerializer(
             attendances,
             many=True,


### PR DESCRIPTION
El endpoint ejecutaba 14 queries por request (escalando linealmente con el número de eventos por página). 

La causa eran dos N+1 en EventSerializer: aunque la vista configuraba prefetch_related, el serializer accedía a las relaciones con .values_list() y .filter(), que ignoran el caché del prefetch y generan una query extra por evento.

Los cambios introducidos son:         
  - serializers.py — get_calendars: cambiado obj.calendars.values_list('id', flat=True) por [c.id for c in obj.calendars.all()]. .all() usa el caché del prefetch; .values_list() no.
  - serializers.py — get_attendees: ahora lee del atributo assisting_attendances (si existe) en lugar de llamar obj.attendances.filter(status='ASSISTING'). Incluye fallback para vistas que no usan el prefetch.                                                                                                                           
  - views.py — list_events: añadido to_attr='assisting_attendances' al Prefetch de asistentes, para que el resultado quede guardado en un atributo nombrado accesible desde el serializer sin nueva query. 