### PR TITLE
fix: revocar permisos de calendario no actualizaba la UI ni eliminaba la suscripción

### DIFF
--- a/backend/current/schema/types.py
+++ b/backend/current/schema/types.py
@@ -358,8 +358,10 @@ class Query(graphene.ObjectType):
 
         current_user = info.context.user
 
+        is_own_profile = current_user.is_authenticated and current_user == target
+        calendar_filter = {"creator": target} if is_own_profile else {"creator": target, "privacy": "PUBLIC"}
         public_calendars = Calendar.objects.filter(
-            creator=target, privacy="PUBLIC"
+            **calendar_filter
         ).select_related("creator").prefetch_related("co_owners", "viewers", "categories")
 
         following_calendars = Calendar.objects.filter(

--- a/backend/current/schema/types.py
+++ b/backend/current/schema/types.py
@@ -359,10 +359,8 @@ class Query(graphene.ObjectType):
 
         current_user = info.context.user
 
-        is_own_profile = current_user.is_authenticated and current_user == target
-        calendar_filter = {"creator": target} if is_own_profile else {"creator": target, "privacy": "PUBLIC"}
         public_calendars = Calendar.objects.filter(
-            **calendar_filter
+            creator=target, privacy="PUBLIC"
         ).select_related("creator").prefetch_related("co_owners", "viewers", "categories")
 
         private_calendars = []

--- a/backend/main/calendars/tests/tests.py
+++ b/backend/main/calendars/tests/tests.py
@@ -1747,3 +1747,159 @@ class LeaveCalendarTests(APITestCase):
         # Verify user is removed from both
         self.assertFalse(self.calendar.co_owners.filter(id=self.co_owner.id).exists())
         self.assertFalse(self.calendar.viewers.filter(id=self.co_owner.id).exists())
+
+
+class UpdateCoOwnersTests(APITestCase):
+    """Tests for PATCH /api/v1/calendars/<id>/co_owners/"""
+
+    def setUp(self):
+        self.creator = User.objects.create_user(
+            username="coowners_creator",
+            email="coowners_creator@example.com",
+            password="testpass123",
+        )
+        self.co_owner_a = User.objects.create_user(
+            username="coowners_a",
+            email="coowners_a@example.com",
+            password="testpass123",
+        )
+        self.co_owner_b = User.objects.create_user(
+            username="coowners_b",
+            email="coowners_b@example.com",
+            password="testpass123",
+        )
+        self.other = User.objects.create_user(
+            username="coowners_other",
+            email="coowners_other@example.com",
+            password="testpass123",
+        )
+        self.calendar = Calendar.objects.create(
+            name="CoOwners Calendar",
+            privacy="PRIVATE",
+            creator=self.creator,
+        )
+        self.calendar.co_owners.add(self.co_owner_a, self.co_owner_b)
+        # Both co-owners are subscribed to the calendar
+        self.co_owner_a.subscribed_calendars.add(self.calendar)
+        self.co_owner_b.subscribed_calendars.add(self.calendar)
+
+    def _url(self):
+        return f"/api/v1/calendars/{self.calendar.id}/co_owners/"
+
+    def test_revoke_co_owner_removes_subscription(self):
+        """Revoking a co-owner must also remove their calendar subscription."""
+        self.client.force_authenticate(self.creator)
+
+        # Remove co_owner_a by sending only co_owner_b
+        response = self.client.patch(
+            self._url(),
+            {"co_owners": [self.co_owner_b.id]},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.co_owner_a.refresh_from_db()
+        self.assertFalse(
+            self.co_owner_a.subscribed_calendars.filter(id=self.calendar.id).exists(),
+            "Revoked co-owner should no longer be subscribed to the calendar.",
+        )
+        # co_owner_b keeps their subscription
+        self.co_owner_b.refresh_from_db()
+        self.assertTrue(
+            self.co_owner_b.subscribed_calendars.filter(id=self.calendar.id).exists(),
+        )
+
+    def test_revoke_all_co_owners_clears_all_subscriptions(self):
+        """Removing all co-owners must unsubscribe every one of them."""
+        self.client.force_authenticate(self.creator)
+
+        response = self.client.patch(
+            self._url(),
+            {"co_owners": []},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.co_owner_a.refresh_from_db()
+        self.co_owner_b.refresh_from_db()
+        self.assertFalse(
+            self.co_owner_a.subscribed_calendars.filter(id=self.calendar.id).exists(),
+        )
+        self.assertFalse(
+            self.co_owner_b.subscribed_calendars.filter(id=self.calendar.id).exists(),
+        )
+
+    def test_keep_co_owner_preserves_subscription(self):
+        """A co-owner that stays in the list must keep their subscription."""
+        self.client.force_authenticate(self.creator)
+
+        response = self.client.patch(
+            self._url(),
+            {"co_owners": [self.co_owner_a.id, self.co_owner_b.id]},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.co_owner_a.refresh_from_db()
+        self.assertTrue(
+            self.co_owner_a.subscribed_calendars.filter(id=self.calendar.id).exists(),
+        )
+
+    def test_non_creator_cannot_update_co_owners(self):
+        """Only the calendar creator may call this endpoint."""
+        self.client.force_authenticate(self.co_owner_a)
+
+        response = self.client.patch(
+            self._url(),
+            {"co_owners": []},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_unauthenticated_returns_401(self):
+        response = self.client.patch(
+            self._url(),
+            {"co_owners": []},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_invalid_payload_returns_400(self):
+        """Non-list payload must be rejected."""
+        self.client.force_authenticate(self.creator)
+
+        response = self.client.patch(
+            self._url(),
+            {"co_owners": "not-a-list"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_nonexistent_user_returns_400(self):
+        """Referencing a user that does not exist must be rejected."""
+        self.client.force_authenticate(self.creator)
+
+        response = self.client.patch(
+            self._url(),
+            {"co_owners": [999999]},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_creator_id_silently_excluded(self):
+        """Including the creator's own ID must be ignored, not cause an error."""
+        self.client.force_authenticate(self.creator)
+
+        response = self.client.patch(
+            self._url(),
+            {"co_owners": [self.creator.id, self.co_owner_a.id]},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(
+            self.calendar.co_owners.filter(id=self.creator.id).exists(),
+        )

--- a/backend/main/calendars/views.py
+++ b/backend/main/calendars/views.py
@@ -508,7 +508,10 @@ def update_viewers(request, calendar_id):
             status=status.HTTP_400_BAD_REQUEST,
         )
 
+    removed_viewers = set(calendar.viewers.all()) - set(users)
     calendar.viewers.set(users)
+    for removed_user in removed_viewers:
+        removed_user.subscribed_calendars.remove(calendar)
 
     return Response({
         'id': calendar.id,

--- a/backend/main/calendars/views.py
+++ b/backend/main/calendars/views.py
@@ -453,7 +453,10 @@ def update_co_owners(request, calendar_id):
             status=status.HTTP_400_BAD_REQUEST,
         )
 
+    removed_co_owners = set(calendar.co_owners.all()) - set(users)
     calendar.co_owners.set(users)
+    for removed_user in removed_co_owners:
+        removed_user.subscribed_calendars.remove(calendar)
 
     return Response({
         'id': calendar.id,

--- a/backend/main/radar/tests/tests.py
+++ b/backend/main/radar/tests/tests.py
@@ -1,4 +1,4 @@
-from datetime import date, time
+from datetime import time
 from rest_framework.test import APITestCase
 from django.core.cache import cache
 from django.utils import timezone
@@ -159,7 +159,7 @@ class RadarEventsTest(APITestCase):
         self.client.login(username="user1", password="testpass")
         own_event = Event.objects.create(
             title="My Own Event",
-            date=date.today(),
+            date=timezone.now().date(),
             time=time(16, 0),
             location=Point(-3.7038, 40.4168),
             creator=self.user,

--- a/frontend/app/(tabs)/calendars.tsx
+++ b/frontend/app/(tabs)/calendars.tsx
@@ -286,6 +286,13 @@ export default function CalendarScreen() {
       return;
     }
 
+    if (updatedCalendar?.id != null) {
+      setInfoCalendar((current) =>
+        current?.id === String(updatedCalendar.id)
+          ? { ...current, ...updatedCalendar }
+          : current,
+      );
+    }
     reload();
   };
 

--- a/frontend/components/calendar-info-modal.tsx
+++ b/frontend/components/calendar-info-modal.tsx
@@ -193,13 +193,14 @@ export function CalendarInfoModal({
       const updatedUsers = currentUsers.filter((u: any) => u.id !== userToRemove.id);
       const userIds = updatedUsers.map((u: any) => u.id);
 
-      await apiClient.patch(`/calendars/${localCalendar.id}/${field}/`, {
+      const response = await apiClient.patch<any>(`/calendars/${localCalendar.id}/${field}/`, {
         [field]: userIds,
       });
 
       const updatedCalendar = {
         ...localCalendar,
-        [field]: updatedUsers,
+        co_owners: Array.isArray(response?.co_owners) ? response.co_owners : (localCalendar.co_owners ?? []),
+        viewers: Array.isArray(response?.viewers) ? response.viewers : (field === 'viewers' ? updatedUsers : (localCalendar.viewers ?? [])),
       } as Calendar;
 
       setLocalCalendar(updatedCalendar);


### PR DESCRIPTION
## Problema
Al revocar permisos de edición o vista a un usuario en un calendario privado:
- El usuario revocado seguía viendo el calendario en su lista `/calendars` y en "Following"
- La pestaña "Shared with" del propietario no se actualizaba visualmente al instante
- El usuario revocado seguía recibiendo actualizaciones del calendario
-
## Solución
- `calendar-info-modal.tsx`: `handleRemoveUser` ahora usa la respuesta del
  servidor para construir `updatedCalendar`, que es la fuente de verdad.
- `calendars.tsx`: `updateCalendarInState` ahora también llama a `setInfoCalendar`
  con los datos fusionados, disparando el `useEffect([calendar])` del modal
  para re-sincronizar `localCalendar`.

## Pasos para reproducir (ya corregido)
1. Usuario1 crea un calendario privado e invita a Usuario2
2. Usuario2 acepta la invitación
3. Usuario1 revoca el permiso desde "Shared with"
4. Usuario2 desaparece de "Shared with" al instante
5. Usuario2 pierde acceso completo al calendario