### PR TITLE
fix: boton home desaparece

### DIFF
--- a/frontend/app/(tabs)/_layout.tsx
+++ b/frontend/app/(tabs)/_layout.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from "@expo/vector-icons";
 import { Href, Link, Slot, useRouter } from "expo-router";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef } from "react";
 import {
   Pressable,
   StyleSheet,
@@ -18,10 +18,50 @@ import { WelcomeModal } from "@/components/tutorial/welcome-modal";
 import { TutorialOverlay } from "@/components/tutorial/tutorial-overlay";
 import { NotificationsProvider } from "@/context/notification-context";
 
+const NavButton = ({
+  icon,
+  href,
+  onPress,
+  measureCreate,
+  createButtonLayout,
+}: {
+  icon: any;
+  href?: Href;
+  onPress?: () => void;
+  measureCreate?: boolean;
+  createButtonLayout?: React.RefObject<{ x: number; y: number; width: number; height: number }>;
+}) => {
+  const button = (
+    <Pressable style={styles.navButton} onPress={onPress}>
+      <Ionicons name={icon} size={24} color="#ffffff" />
+    </Pressable>
+  );
+
+  if (measureCreate) {
+    return (
+      <View
+        onLayout={(e) => {
+          (e.target as any)?.measure?.((_px: number, _py: number, pw: number, ph: number, pageX: number, pageY: number) => {
+            if (createButtonLayout) {
+              createButtonLayout.current = { x: pageX, y: pageY, width: pw, height: ph };
+            }
+          });
+        }}
+      >
+        {href ? <Link href={href} asChild>{button}</Link> : button}
+      </View>
+    );
+  }
+
+  if (href) {
+    return <Link href={href} asChild>{button}</Link>;
+  }
+  return button;
+};
+
 function InnerLayout() {
   const { width } = useWindowDimensions();
   const isDesktop = width >= 768;
-  const [expanded, setExpanded] = useState(false);
   const { isLoading } = useAuth();
   const router = useRouter();
 
@@ -53,48 +93,6 @@ function InnerLayout() {
     return () => clearTimeout(t);
   }, []);
 
-  const contentRef = useRef<View>(null);
-
-  const NavButton = ({
-    icon,
-    href,
-    onPress,
-    measureCreate,
-  }: {
-    icon: any;
-    href?: Href;
-    onPress?: () => void;
-    measureCreate?: boolean;
-  }) => {
-    const button = (
-      <Pressable style={styles.navButton} onPress={onPress}>
-        <Ionicons name={icon} size={24} color="#ffffff" />
-      </Pressable>
-    );
-
-    if (measureCreate) {
-      return (
-        <View
-          onLayout={(e) => {
-            const { x, y, width: w, height: h } = e.nativeEvent.layout;
-            contentRef.current?.measure((_fx, _fy, _fw, contentH) => {
-              (e.target as any)?.measure?.((px: number, py: number, pw: number, ph: number, pageX: number, pageY: number) => {
-                createButtonLayout.current = { x: pageX, y: pageY, width: pw, height: ph };
-              });
-            });
-          }}
-        >
-          {href ? <Link href={href} asChild>{button}</Link> : button}
-        </View>
-      );
-    }
-
-    if (href) {
-      return <Link href={href} asChild>{button}</Link>;
-    }
-    return button;
-  };
-
   if (isLoading) {
     return (
       <View style={[styles.container, { justifyContent: "center", alignItems: "center" }]}>
@@ -106,14 +104,14 @@ function InnerLayout() {
   return (
     <View style={styles.container}>
       <WelcomeModal />
-      {isDesktop && <Sidebar expanded={expanded} setExpanded={setExpanded} />}
+      {isDesktop && <Sidebar />}
 
-      <View ref={contentRef} style={styles.content}>
+      <View style={styles.content}>
         {!isDesktop && <TopBar />}
         <Slot />
         {!isDesktop && <BottomBar NavButton={(props: any) =>
           props.icon === "add-circle"
-            ? <NavButton {...props} measureCreate />
+            ? <NavButton {...props} measureCreate createButtonLayout={createButtonLayout} />
             : <NavButton {...props} />
         } />}
         <TutorialOverlay />

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -11,13 +11,15 @@ import "../global.css";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { Platform, Pressable, StyleSheet, Text, View } from "react-native";
+import * as Font from "expo-font";
+import { Ionicons } from "@expo/vector-icons";
 
 import { APP_BACKGROUND, Colors } from "@/constants/theme";
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import { useAuth } from "@/hooks/use-auth";
 import AuthProvider from "../context/auth-context";
 import { TutorialProvider } from "@/context/tutorial-context";
-import { usePathname, useSegments } from "expo-router";
+import { usePathname } from "expo-router";
 import { getRouteProtection } from "../routes-config";
 
 export const unstable_settings = {
@@ -64,10 +66,10 @@ export default function RootLayout() {
 }
 
 function RootLayoutContent() {
+  const [fontsLoaded] = Font.useFonts(Ionicons.font);
   const router = useRouter();
   const colorScheme = useColorScheme();
   const { isAuthenticated, isLoading } = useAuth();
-  const segments = useSegments();
   const pathname = usePathname();
   const [cookiePreference, setCookiePreference] =
     useState<CookiePreference | null>(null);
@@ -147,6 +149,8 @@ function RootLayoutContent() {
       }
     }
   }, [isAuthenticated, isLoading, pathname, router]);
+
+  if (!fontsLoaded) return null;
 
   const saveCookiePreference = (value: CookiePreference) => {
     setCookiePreference(value);

--- a/frontend/components/nav_bar/side-bar.tsx
+++ b/frontend/components/nav_bar/side-bar.tsx
@@ -1,6 +1,6 @@
 import { View, Pressable, Image } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
-import { Link, type Href, useRouter } from "expo-router";
+import { useRouter } from "expo-router";
 import { useState } from "react";
 import { useAuth } from "@/hooks/use-auth";
 import { ImportCalendarModal } from '@/components/import-calendar-modal';
@@ -8,39 +8,20 @@ import { navSideBarStyles } from "@/styles/ui-styles";
 import { CreateMenuModal } from "@/components/nav_bar/create-menu-modal";
 import { useNotificationsContext } from "@/context/notification-context";
 
-interface SidebarProps {
-  expanded: boolean;
-  setExpanded: (value: boolean) => void;
-}
-
 const SidebarItem = ({
   icon,
-  href,
   onPress,
 }: {
   icon: any;
   label: string;
-  href?: string;
   onPress?: () => void;
-}) => {
-  const content = (
-    <Pressable style={navSideBarStyles.sidebarItem} onPress={onPress}>
-      <Ionicons name={icon} size={22} color="#ffffff" />
-    </Pressable>
-  );
+}) => (
+  <Pressable style={navSideBarStyles.sidebarItem} onPress={onPress}>
+    <Ionicons name={icon} size={22} color="#ffffff" />
+  </Pressable>
+);
 
-  if (href) {
-    return (
-      <Link href={href as Href} asChild>
-        {content}
-      </Link>
-    );
-  }
-
-  return content;
-};
-
-export default function Sidebar({ expanded, setExpanded }: SidebarProps) {
+export default function Sidebar() {
   const [menuVisible, setMenuVisible] = useState(false);
   const router = useRouter();
   const { isAuthenticated, user } = useAuth();
@@ -70,7 +51,7 @@ export default function Sidebar({ expanded, setExpanded }: SidebarProps) {
   };
 
   const profileHref: string = isAuthenticated ? "/profile" : "/login";
-  const homeHref: string = isAuthenticated ? "/(tabs)/calendars" : "/login";
+  const homeHref: string = isAuthenticated ? "/calendars" : "/login";
   const notificationsHref: string = isAuthenticated ? "/(tabs)/notifications" : "/login";
 
   return (
@@ -84,13 +65,13 @@ export default function Sidebar({ expanded, setExpanded }: SidebarProps) {
       </View>
 
       <View style={navSideBarStyles.sidebarCenter}>
-        <SidebarItem icon="home" label="Home" href={homeHref} />
-        <SidebarItem icon="search" label="Search" href="/(tabs)/search" />
+        <SidebarItem icon="home" label="Home" onPress={() => router.push(homeHref as any)} />
+        <SidebarItem icon="search" label="Search" onPress={() => router.push("/(tabs)/search" as any)} />
         <SidebarItem icon="add-circle" label="Create" onPress={handleAddPress} />
-        <SidebarItem icon="calendar" label="Discover" href="/(tabs)/switch-calendar" />
-        <SidebarItem icon="compass" label="Map" href="/radar" />
+        <SidebarItem icon="calendar" label="Discover" onPress={() => router.push("/(tabs)/switch-calendar" as any)} />
+        <SidebarItem icon="compass" label="Map" onPress={() => router.push("/radar" as any)} />
         <View style={{ position: "relative" }}>
-          <SidebarItem icon="notifications" label="Notifications" href={notificationsHref} />
+          <SidebarItem icon="notifications" label="Notifications" onPress={() => router.push(notificationsHref as any)} />
           {unreadCount > 0 && (
             <View style={{
               position: "absolute",
@@ -106,42 +87,41 @@ export default function Sidebar({ expanded, setExpanded }: SidebarProps) {
             }} />
           )}
         </View>
-        <SidebarItem icon="person" label={profileHref} href={profileHref} />
+        <SidebarItem icon="person" label="Profile" onPress={() => router.push(profileHref as any)} />
         {user?.plan === 'BUSINESS' && (
-          <SidebarItem icon="bar-chart" label="Analytics" href="/(tabs)/analytics" />
+          <SidebarItem icon="bar-chart" label="Analytics" onPress={() => router.push("/(tabs)/analytics" as any)} />
         )}
-
-        <CreateMenuModal
-          visible={menuVisible}
-          onClose={closeMenu}
-          onNewEvent={() => {
-            if (isAuthenticated) {
-              navigateTo(`/create_events?date=${getTodayFormatted()}`);
-            } else {
-              closeMenu();
-              router.push("/login");
-            }
-          }}
-          onNewCalendar={() => {
-            if (isAuthenticated) {
-              navigateTo("/create");
-            } else {
-              closeMenu();
-              router.push("/login");
-            }
-          }}
-          onImportCalendar={() => {
-            if (isAuthenticated) {
-              closeMenu();
-              setImportVisible(true);
-            } else {
-              closeMenu();
-              router.push("/login");
-            }
-          }}
-        />
       </View>
 
+      <CreateMenuModal
+        visible={menuVisible}
+        onClose={closeMenu}
+        onNewEvent={() => {
+          if (isAuthenticated) {
+            navigateTo(`/create_events?date=${getTodayFormatted()}`);
+          } else {
+            closeMenu();
+            router.push("/login");
+          }
+        }}
+        onNewCalendar={() => {
+          if (isAuthenticated) {
+            navigateTo("/create");
+          } else {
+            closeMenu();
+            router.push("/login");
+          }
+        }}
+        onImportCalendar={() => {
+          if (isAuthenticated) {
+            closeMenu();
+            setImportVisible(true);
+          } else {
+            closeMenu();
+            router.push("/login");
+          }
+        }}
+      />
       <ImportCalendarModal visible={importVisible} onClose={() => setImportVisible(false)} />
     </View>
   );

--- a/frontend/styles/ui-styles.ts
+++ b/frontend/styles/ui-styles.ts
@@ -74,7 +74,9 @@ export const navTopBarStyles = StyleSheet.create({
 
 export const navSideBarStyles = StyleSheet.create({
   sidebar: {
+    flex: 1,
     width: 80,
+    maxWidth: 80,
     backgroundColor: '#10464d',
     paddingVertical: 20,
     justifyContent: 'space-between',
@@ -138,12 +140,16 @@ export const navSideBarStyles = StyleSheet.create({
   sidebarCenter: {
     flex: 1,
     justifyContent: 'center',
-    gap: 30,
+    alignItems: 'center',
+    gap: 24,
+    overflow: 'visible',
   },
   sidebarItem: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 15,
+    justifyContent: 'center',
+    minHeight: 30,
+    minWidth: 30,
   },
   closeBtn: {
     marginTop: 10,


### PR DESCRIPTION
En Expo Web, las fuentes de vector-icons se solicitaban en tiempo de ejecución por red, causando errores 404 intermitentes que hacían que los iconos del sidebar (especialmente el botón home) desaparecieran aleatoriamente al recargar.

Se soluciona precargando Ionicons.font con el hook useFonts de expo-font en el layout raíz, bloqueando el renderizado hasta que la fuente esté lista. También se elimina una referencia obsoleta a SidebarProps que impedía silenciosamente que el módulo del sidebar compilara, y se mueve CreateMenuModal fuera de sidebarCenter para que no ocupe espacio flex y recorte el primer icono.