### PR TITLE
fix: limitar caracteres y boton en comentarios

### DIFF
--- a/backend/main/migrations/0033_limit_bio_and_calendar_description.py
+++ b/backend/main/migrations/0033_limit_bio_and_calendar_description.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0032_feedback_model'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='user',
+            name='bio',
+            field=models.TextField(blank=True, max_length=150),
+        ),
+        migrations.AlterField(
+            model_name='calendar',
+            name='description',
+            field=models.TextField(blank=True, max_length=500),
+        ),
+    ]

--- a/backend/main/models.py
+++ b/backend/main/models.py
@@ -21,7 +21,7 @@ class User(AbstractUser):
     ]
     email = models.EmailField(unique=True)
     pronouns = models.CharField(max_length=150, blank=True)
-    bio = models.TextField(blank=True)
+    bio = models.TextField(blank=True, max_length=150)
     link = models.URLField(blank=True)
     plan = models.CharField(max_length=20, default='FREE', choices=PLAN_CHOICES)
     photo = models.ImageField(upload_to='profiles/', null=True, blank=True)
@@ -84,7 +84,7 @@ class Calendar(models.Model):
     origin = models.CharField(max_length=20, choices=ORIGIN_CHOICES, default='CURRENT')
     external_id = models.CharField(max_length=255, null=True, blank=True, db_index=True)
     name = models.CharField(max_length=100)
-    description = models.TextField(blank=True)
+    description = models.TextField(blank=True, max_length=500)
     cover = models.ImageField(upload_to=calendar_cover_path, null=True, blank=True)
     privacy = models.CharField(max_length=10, choices=PRIVACY_CHOICES, default='PRIVATE')
     creator = models.ForeignKey(User, on_delete=models.CASCADE, related_name='created_calendars')

--- a/frontend/app/(tabs)/create.tsx
+++ b/frontend/app/(tabs)/create.tsx
@@ -383,8 +383,10 @@ export default function CreateScreen() {
               }
               multiline
               numberOfLines={3}
+              maxLength={500}
               testID="create-calendar-description-input"
             />
+            <Text style={styles.charCount}>{calendarData.description.length}/500</Text>
           </View>
 
           <View style={styles.divider} />
@@ -617,6 +619,12 @@ const styles = StyleSheet.create({
   inputMultiline: {
     height: 90,
     textAlignVertical: "top",
+  },
+  charCount: {
+    fontSize: 12,
+    color: "#999",
+    textAlign: "right",
+    marginTop: 4,
   },
   divider: {
     height: 1,

--- a/frontend/app/(tabs)/edit.tsx
+++ b/frontend/app/(tabs)/edit.tsx
@@ -378,7 +378,9 @@ export default function EditScreen() {
               }
               multiline
               numberOfLines={3}
+              maxLength={500}
             />
+            <Text style={styles.charCount}>{calendarData.description.length}/500</Text>
           </View>
 
           <View style={styles.divider} />
@@ -586,6 +588,12 @@ const styles = StyleSheet.create({
   inputMultiline: {
     height: 90,
     textAlignVertical: "top",
+  },
+  charCount: {
+    fontSize: 12,
+    color: "#999",
+    textAlign: "right",
+    marginTop: 4,
   },
   divider: {
     height: 1,

--- a/frontend/app/(tabs)/profile/profileEdit.tsx
+++ b/frontend/app/(tabs)/profile/profileEdit.tsx
@@ -203,8 +203,9 @@ const EditProfileScreen = () => {
               multiline
               numberOfLines={4}
               textAlignVertical="top"
+              maxLength={150}
             />
-            <Text style={profileStyles.editCharacterCount}>{bio.length} characters</Text>
+            <Text style={profileStyles.editCharacterCount}>{bio.length}/150</Text>
           </View>
         </View>
  

--- a/frontend/components/comments-modal-c.tsx
+++ b/frontend/components/comments-modal-c.tsx
@@ -498,6 +498,7 @@ export default function CommentsModalC({
                     onChangeText={setText}
                     editable={!sending}
                     multiline={false}
+                    maxLength={500}
                   />
 
                   <Pressable onPress={handleSubmit} disabled={sending || !text.trim()}>
@@ -574,13 +575,16 @@ const styles = StyleSheet.create({
     zIndex: 40,
     width: 28,
     height: 28,
+    borderRadius: 14,
+    backgroundColor: "rgba(0,0,0,0.35)",
     alignItems: "center",
     justifyContent: "center",
   },
 
   closeText: {
-    fontSize: 22,
-    color: TEXT,
+    fontSize: 16,
+    color: "#ffffff",
+    lineHeight: 18,
   },
 
   image: {

--- a/frontend/components/comments-modal.tsx
+++ b/frontend/components/comments-modal.tsx
@@ -493,6 +493,7 @@ export default function CommentsModal({
                     onChangeText={setText}
                     editable={!sending}
                     multiline={false}
+                    maxLength={500}
                   />
 
                   <Pressable onPress={handleSubmit} disabled={sending || !text.trim()}>
@@ -577,13 +578,16 @@ const styles = StyleSheet.create({
     zIndex: 40,
     width: 28,
     height: 28,
+    borderRadius: 14,
+    backgroundColor: "rgba(0,0,0,0.35)",
     alignItems: "center",
     justifyContent: "center",
   },
 
   closeText: {
-    fontSize: 22,
-    color: TEXT,
+    fontSize: 16,
+    color: "#ffffff",
+    lineHeight: 18,
   },
 
   image: {


### PR DESCRIPTION
Se ha establecido un limite de caracteres en:
- Comentario de calendarios (500)
- Descripción de los calendarios (500)
- Biografía del perfil (150)
Asimismo se ha arreglado el botón de cerrar el modal de comentarios que era invisible.
